### PR TITLE
Create new mutect2ConsensusTumorOnly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mutect2ConsensusTumorOnly
 
-The Mutect2Consensus workflow will process umiConsensus outputs for the tumour data through mutect2 in tumour only mode to call variants then use information from the matched normal to identify likely germline variants.
+The Mutect2Consensus workflow will process umiConsensus outputs for the tumour data through mutect2 in tumour only mode to call variants and annotation.
 
 ## Overview
 
@@ -148,140 +148,141 @@ Output | Type | Description
 `tumorMafOutput`|File?|maf output for tumor sample
 `filterredMaf`|File?|maf file after filtering
 
+
 ## Commands
-This section lists command(s) run by mutect2ConsensusTumorOnly workflow
-
-* Running mutect2ConsensusTumorOnly
-
+ This section lists command(s) run by mutect2ConsensusTumorOnly workflow
+ 
+ * Running mutect2ConsensusTumorOnly
+ 
+ 
 ```
-    basename ~{fileName} | cut -d. -f1 
-```
-```
-  python3<<CODE
-  import subprocess
-  import sys
-  inputStrings = []
-  v = "~{sep=' ' inputVcfs}"
-  vcfFiles = v.split()
-  w = "~{sep=' ' workflows}"
-  workflowIds = w.split()
-  priority = "~{priority}"
-  
-  if len(vcfFiles) != len(workflowIds):
-      print("The arrays with input files and their respective workflow names are not of equal size!")
-  else:
-      for f in range(0, len(vcfFiles)):
-          inputStrings.append("--variant:" + workflowIds[f] + " " + vcfFiles[f])
-
-  javaMemory = ~{jobMemory} - 6 
-  gatkCommand  = "$JAVA_ROOT/bin/java -Xmx" + str(javaMemory) + "G -jar $GATK_ROOT/GenomeAnalysisTK.jar "
-  gatkCommand += "-T CombineVariants "
-  gatkCommand += " ".join(inputStrings)
-  gatkCommand += " -R ~{referenceFasta} "
-  gatkCommand += "-o ~{outputPrefix}_combined.vcf.gz "
-  gatkCommand += "-genotypeMergeOptions PRIORITIZE "
-  gatkCommand += "-priority " + priority
-  gatkCommand += " 2>&1"
-
-  result_output = subprocess.run(gatkCommand, shell=True)
-  sys.exit(result_output.returncode)
-  
+     basename ~{fileName} | cut -d. -f1 
 ```
 ```
-  bcftools annotate -a ~{uniqueVcf} \
- -c FMT/AD,FMT/DP ~{mergedVcf} -Oz \
- -o "~{outputPrefix}.merged.vcf.gz"
-
- tabix -p vcf "~{outputPrefix}.merged.vcf.gz"
+   python3<<CODE
+   import subprocess
+   import sys
+   inputStrings = []
+   v = "~{sep=' ' inputVcfs}"
+   vcfFiles = v.split()
+   w = "~{sep=' ' workflows}"
+   workflowIds = w.split()
+   priority = "~{priority}"
+   
+   if len(vcfFiles) != len(workflowIds):
+       print("The arrays with input files and their respective workflow names are not of equal size!")
+   else:
+       for f in range(0, len(vcfFiles)):
+           inputStrings.append("--variant:" + workflowIds[f] + " " + vcfFiles[f])
+ 
+   javaMemory = ~{jobMemory} - 6 
+   gatkCommand  = "$JAVA_ROOT/bin/java -Xmx" + str(javaMemory) + "G -jar $GATK_ROOT/GenomeAnalysisTK.jar "
+   gatkCommand += "-T CombineVariants "
+   gatkCommand += " ".join(inputStrings)
+   gatkCommand += " -R ~{referenceFasta} "
+   gatkCommand += "-o ~{outputPrefix}_combined.vcf.gz "
+   gatkCommand += "-genotypeMergeOptions PRIORITIZE "
+   gatkCommand += "-priority " + priority
+   gatkCommand += " 2>&1"
+ 
+   result_output = subprocess.run(gatkCommand, shell=True)
+   sys.exit(result_output.returncode)
+   CODE
 ```
 ```
-    python3<<CODE
-    ## Adapted from https://github.com/oicr-gsi/djerba/blob/GCGI-806_v1.0.0-dev/src/lib/djerba/plugins/tar/snv_indel/plugin.py
-    ## this code will filter a maf file, generated from tumor-only mutect2 calls to identify likely germline calls generated from a mutect2 calls from the matched normal
-    import pandas as pd
-    maf_file_path = "~{mafFile}"
-    maf_normal_path = "~{mafNormalFile}"
-    freq_list_path = "~{freqList}"
-    output_path_prefix = "~{outputPrefix}"
-    genes_to_keep_path = "~{genesToKeep}"
-
-    if maf_normal_path:
-      df_bc = pd.read_csv(maf_normal_path,
-                      sep = "\t",
-                      on_bad_lines="error",
-                      compression='gzip',
-                      skiprows=[0])
-
-    df_pl = pd.read_csv(maf_file_path,
-                    sep = "\t",
-                    on_bad_lines="error",
-                    compression='gzip',
-                    skiprows=[0])
-    df_freq = pd.read_csv(freq_list_path,
-                  sep = "\t")
-    with open(genes_to_keep_path) as f:
-      GENES_TO_KEEP = f.read()
-
-
-    for row in df_pl.iterrows():
-      hugo_symbol = row[1]['Hugo_Symbol']
-      chromosome = row[1]['Chromosome']
-      start_position = row[1]['Start_Position']
-      reference_allele = row[1]['Reference_Allele']
-      allele = row[1]['Allele']
-
-      # If there is normal input, annotate rows with information from the matched normal and from the frequency table
-      if maf_normal_path:
-        # Lookup the entry in the BC and annotate the tumour maf with
-        #   n_depth, n_ref_count, n_alt_count
-
-        row_lookup = df_bc[(df_bc['Hugo_Symbol'] == hugo_symbol) & 
-                    (df_bc['Chromosome'] == chromosome) & 
-                    (df_bc['Start_Position'] == start_position) &
-                    (df_bc['Reference_Allele'] == reference_allele) &
-                    (df_bc['Allele'] == allele)]
-
-
-        # If there's only one entry, take its normal values
-        if len(row_lookup) == 1:
-            df_pl.at[row[0], "n_depth"] = row_lookup['n_depth'].item()
-            df_pl.at[row[0], "n_ref_count"] = row_lookup['n_ref_count'].item()
-            df_pl.at[row[0], "n_alt_count"] = row_lookup['n_alt_count'].item()
-      
-        # If the entry isn't in the table, 
-        # or if there is more than one value and so you can't choose which normal values to take, 
-        # set them as 0
-        else:
-            df_pl.at[row[0], "n_depth"] = 0
-            df_pl.at[row[0], "n_ref_count"] = 0
-            df_pl.at[row[0], "n_alt_count"] = 0
-            
-      # Lookup the entry in the frequency table and annotate the tumour maf with Freq
-    
-      row_lookup = df_freq[(df_freq['Start_Position'] == row[1]['Start_Position']) &
-                          (df_freq['Reference_Allele'] == row[1]['Reference_Allele']) &
-                          ((df_freq['Tumor_Seq_Allele'] == row[1]['Tumor_Seq_Allele1']) |
-                          (df_freq['Tumor_Seq_Allele'] == row[1]['Tumor_Seq_Allele2']))]
-
-      if len(row_lookup) > 0:
-          df_pl.at[row[0], 'Freq'] = row_lookup['Freq'].item()
-      else:
-          df_pl.at[row[0], 'Freq'] = 0
-
-    # Filter the maf to remove rows based on various criteria, but always maintaining genes in the GENES_TO_KEEP list  
-    for row in df_pl.iterrows():
-        hugo_symbol = row[1]['Hugo_Symbol']
-        frequency = row[1]['Freq']
-        gnomAD_AF = row[1]['gnomAD_AF']
-        n_alt_count = row[1]['n_alt_count']
-        if hugo_symbol not in GENES_TO_KEEP or frequency > 0.1 or n_alt_count > 4 or gnomAD_AF > 0.001:
-            df_pl = df_pl.drop(row[0])   
-
-    df_pl.to_csv(output_path_prefix + '_filtered_maf_for_tar.maf.gz', sep = "\t", compression='gzip', index=False)
-    CODE
+   bcftools annotate -a ~{uniqueVcf} \
+  -c FMT/AD,FMT/DP ~{mergedVcf} -Oz \
+  -o "~{outputPrefix}.merged.vcf.gz"
+ 
+  tabix -p vcf "~{outputPrefix}.merged.vcf.gz"
 ```
-
-## Support
+```
+     python3<<CODE
+     ## Adapted from https://github.com/oicr-gsi/djerba/blob/GCGI-806_v1.0.0-dev/src/lib/djerba/plugins/tar/snv_indel/plugin.py
+     ## this code will filter a maf file, generated from tumor-only mutect2 calls 
+     import pandas as pd
+     maf_file_path = "~{mafFile}"
+     maf_normal_path = "~{mafNormalFile}"
+     freq_list_path = "~{freqList}"
+     output_path_prefix = "~{outputPrefix}"
+     genes_to_keep_path = "~{genesToKeep}"
+ 
+     if maf_normal_path:
+       df_bc = pd.read_csv(maf_normal_path,
+                       sep = "\t",
+                       on_bad_lines="error",
+                       compression='gzip',
+                       skiprows=[0])
+ 
+     df_pl = pd.read_csv(maf_file_path,
+                     sep = "\t",
+                     on_bad_lines="error",
+                     compression='gzip',
+                     skiprows=[0])
+     df_freq = pd.read_csv(freq_list_path,
+                   sep = "\t")
+     with open(genes_to_keep_path) as f:
+       GENES_TO_KEEP = f.read()
+ 
+ 
+     for row in df_pl.iterrows():
+       hugo_symbol = row[1]['Hugo_Symbol']
+       chromosome = row[1]['Chromosome']
+       start_position = row[1]['Start_Position']
+       reference_allele = row[1]['Reference_Allele']
+       allele = row[1]['Allele']
+ 
+       # If there is normal input, annotate rows with information from the matched normal and from the frequency table
+       if maf_normal_path:
+         # Lookup the entry in the BC and annotate the tumour maf with
+         #   n_depth, n_ref_count, n_alt_count
+ 
+         row_lookup = df_bc[(df_bc['Hugo_Symbol'] == hugo_symbol) & 
+                     (df_bc['Chromosome'] == chromosome) & 
+                     (df_bc['Start_Position'] == start_position) &
+                     (df_bc['Reference_Allele'] == reference_allele) &
+                     (df_bc['Allele'] == allele)]
+ 
+ 
+         # If there's only one entry, take its normal values
+         if len(row_lookup) == 1:
+             df_pl.at[row[0], "n_depth"] = row_lookup['n_depth'].item()
+             df_pl.at[row[0], "n_ref_count"] = row_lookup['n_ref_count'].item()
+             df_pl.at[row[0], "n_alt_count"] = row_lookup['n_alt_count'].item()
+       
+         # If the entry isn't in the table, 
+         # or if there is more than one value and so you can't choose which normal values to take, 
+         # set them as 0
+         else:
+             df_pl.at[row[0], "n_depth"] = 0
+             df_pl.at[row[0], "n_ref_count"] = 0
+             df_pl.at[row[0], "n_alt_count"] = 0
+             
+       # Lookup the entry in the frequency table and annotate the tumour maf with Freq
+     
+       row_lookup = df_freq[(df_freq['Start_Position'] == row[1]['Start_Position']) &
+                           (df_freq['Reference_Allele'] == row[1]['Reference_Allele']) &
+                           ((df_freq['Tumor_Seq_Allele'] == row[1]['Tumor_Seq_Allele1']) |
+                           (df_freq['Tumor_Seq_Allele'] == row[1]['Tumor_Seq_Allele2']))]
+ 
+       if len(row_lookup) > 0:
+           df_pl.at[row[0], 'Freq'] = row_lookup['Freq'].item()
+       else:
+           df_pl.at[row[0], 'Freq'] = 0
+ 
+     # Filter the maf to remove rows based on various criteria, but always maintaining genes in the GENES_TO_KEEP list  
+     for row in df_pl.iterrows():
+         hugo_symbol = row[1]['Hugo_Symbol']
+         frequency = row[1]['Freq']
+         gnomAD_AF = row[1]['gnomAD_AF']
+         n_alt_count = row[1]['n_alt_count']
+         if hugo_symbol not in GENES_TO_KEEP or frequency > 0.1 or n_alt_count > 4 or gnomAD_AF > 0.001:
+             df_pl = df_pl.drop(row[0])   
+ 
+     df_pl.to_csv(output_path_prefix + '_filtered_maf_for_tar.maf.gz', sep = "\t", compression='gzip', index=False)
+     CODE
+```
+ ## Support
 
 For support, please file an issue on the [Github project](https://github.com/oicr-gsi) or send an email to gsi@oicr.on.ca .
 

--- a/mutect2ConsensusTumorOnly.wdl
+++ b/mutect2ConsensusTumorOnly.wdl
@@ -74,12 +74,10 @@ workflow mutect2ConsensusTumorOnly {
 
   parameter_meta {
     tumorInputGroup: "partitioned bam files from umiConsensus outputs for tumor sample"
-    normalInputGroup: "partitioned bam files from umiConsensus outputs for normal sample"
     outputFileNamePrefix: "Prefix to use for output file"
     intervalFile: "interval file to subset variant calls"
     inputIntervalsToParalellizeBy: "intervals for parallelization"
     tumorName: "Name of the tumor sample"
-    normalName: "name of the normal sample"
     reference: "reference version"
   }
 
@@ -163,7 +161,7 @@ workflow mutect2ConsensusTumorOnly {
   meta {
     author: "Alexander Fortuna, Rishi Shah and Gavin Peng"
     email: "alexander.fortuna@oicr.on.ca, rshah@oicr.on.ca, and gpeng@oicr.on.ca"
-    description: "The Mutect2Consensus workflow will process umiConsensus outputs for the tumour data through mutect2 in tumour only mode to call variants then use information from the matched normal to identify likely germline variants."
+    description: "The Mutect2Consensus workflow will process umiConsensus outputs for the tumour data through mutect2 in tumour only mode to call variants and annotation."
     dependencies: [
       {
         name: "gatk/3.6-0",
@@ -400,7 +398,7 @@ task filterMaf {
   command <<<
     python3<<CODE
     ## Adapted from https://github.com/oicr-gsi/djerba/blob/GCGI-806_v1.0.0-dev/src/lib/djerba/plugins/tar/snv_indel/plugin.py
-    ## this code will filter a maf file, generated from tumor-only mutect2 calls to identify likely germline calls generated from a mutect2 calls from the matched normal
+    ## this code will filter a maf file, generated from tumor-only mutect2 calls 
     import pandas as pd
     maf_file_path = "~{mafFile}"
     maf_normal_path = "~{mafNormalFile}"

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -3,6 +3,9 @@
         "id": "TEST_0001",
         "description": "runs the mutect2ConsensusTumorOnly workflow with tumor/normal inputs",
         "arguments": {
+            "mutect2ConsensusTumorOnly.inputIntervalsToParalellizeBy": "chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr20,chr21,chr22,chrX,chrY",
+            "mutect2ConsensusTumorOnly.intervalFile": "/.mounts/labs/gsi/testdata/mutect2Consensus/input_data/CHARM.TS.hg38.bed",
+            "mutect2ConsensusTumorOnly.filterMaf.mafNormalFile": null,
             "mutect2ConsensusTumorOnly.annotation.jobMemory": null,
             "mutect2ConsensusTumorOnly.annotation.modules": null,
             "mutect2ConsensusTumorOnly.annotation.threads": null,


### PR DESCRIPTION
When trying to add tumor only mode to mutect2Consensus, wdl syntax issue for optional value still not solved. 
After much effort removed scatter to adress optional array from collecting scatter can not indexing its elememts ( and resulting a lot of repeating and renaming), the work in progress is in: https://github.com/oicr-gsi/mutect2Consensus/blob/gavin_updates/mutect2Consensus.wdl
then other place with optional nested struct again can not access its fields, and report error:
Failed to process workflow definition 'mutect2Consensus' (reason 1 of 2): Failed to process 'call mutect2.mutect2 as sscsScMatchedMutect2' (reason 1 of 2): Failed to process expression 'normalInputGroup_.sscsScBamAndIndex.bam' (reason 1 of 1): No such field 'sscsScBamAndIndex' on type WomCompositeType {
 dcsScBamAndIndex -> WomCompositeType {
 bam -> File
bamIndex -> File 
}
sscsScBamAndIndex -> WomCompositeType {
 bam -> File
bamIndex -> File 
}
allUniqueBamAndIndex -> WomCompositeType {
 bam -> File
bamIndex -> File 
} 
}?
Failed to process workflow definition 'mutect2Consensus' (reason 2 of 2): Failed to process 'call mutect2.mutect2 as sscsScMatchedMutect2' (reason 2 of 2): Failed to process expression 'normalInputGroup_.sscsScBamAndIndex.bamIndex' (reason 1 of 1): No such field 'sscsScBamAndIndex' on type WomCompositeType {
 dcsScBamAndIndex -> WomCompositeType {
 bam -> File
bamIndex -> File 
}
sscsScBamAndIndex -> WomCompositeType {
 bam -> File
bamIndex -> File 
}
allUniqueBamAndIndex -> WomCompositeType {
 bam -> File
bamIndex -> File 
} 
}?

This shows even after use select_first to try to convert it to non-optional, wdl still treat it as optional.

So I am creating another repo to write the tumor only mode for the wdl. 